### PR TITLE
Disable uBlock's Cosmetic Filter for Sponsor Logos

### DIFF
--- a/dev2018/assets/css/2018.css
+++ b/dev2018/assets/css/2018.css
@@ -369,7 +369,7 @@ nav ul li .fa {
     margin-bottom: 20px;
 }
 
-#main #sponsors .sponsor-block {
+#main #sponsors .sponsors-block {
     background-color: white;
     border: 3px solid #001220;
     display: inline-block !important;
@@ -380,8 +380,8 @@ nav ul li .fa {
     text-align: center;
     position: relative;
 }
-#main #sponsors .sponsor-block.deloitte { background-color: #242122; }
-#main #sponsors .sponsor-logo {
+#main #sponsors .sponsors-block.deloitte { background-color: #242122; }
+#main #sponsors .sponsors-logo {
     display: inline-block !important;
     height: auto;
     max-height: 80%;

--- a/dev2018/index.html
+++ b/dev2018/index.html
@@ -230,21 +230,21 @@
             <h2>Sponsors</h2>
 
             <div class="separator">Main</div>
-            <a class="sponsor-block" href="http://www.natixis.com/">
-                <img class="sponsor-logo main" src="assets/images/sponsors/natixis.png" alt="Natixis">
+            <a class="sponsors-block" href="http://www.natixis.com/">
+                <img class="sponsors-logo main" src="assets/images/sponsors/natixis.png" alt="Natixis">
             </a>
 
             <div class="separator">Gold</div>
-            <a class="sponsor-block" href="http://www.sonae.pt/">
-                <img class="sponsor-logo gold" src="assets/images/sponsors/sonae.png" alt="Sonae">
+            <a class="sponsors-block" href="http://www.sonae.pt/">
+                <img class="sponsors-logo gold" src="assets/images/sponsors/sonae.png" alt="Sonae">
             </a>
 
             <div class="separator">Silver</div>
-            <a class="sponsor-block deloitte" href="http://www2.deloitte.com/">
-                <img class="sponsor-logo silver" src="assets/images/sponsors/deloitte.png" alt="Deloitte">
+            <a class="sponsors-block deloitte" href="http://www2.deloitte.com/">
+                <img class="sponsors-logo silver" src="assets/images/sponsors/deloitte.png" alt="Deloitte">
             </a>
-            <a class="sponsor-block" href="http://www.mindera.com/">
-                <img class="sponsor-logo silver" src="assets/images/sponsors/mindera.png" alt="Mindera">
+            <a class="sponsors-block" href="http://www.mindera.com/">
+                <img class="sponsors-logo silver" src="assets/images/sponsors/mindera.png" alt="Mindera">
             </a>
 
         </section>


### PR DESCRIPTION
uBlock is hiding the sponsor logos on the website.
This fix allows the logos on the dev2018 to be displayed even when uBlock's Cosmetic Filter is enabled.
The main page still needs to be fixed as well.