### PR TITLE
Add Schedule component

### DIFF
--- a/src/components/schedule/Event.js
+++ b/src/components/schedule/Event.js
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Link } from "gatsby";
+
+const Event = ({ title, startTime, endTime, speakers, slug }) => (
+    <div>
+        <h4>
+            {slug ? (
+                <Link to={`/${slug}`}>
+                    {title}
+                </Link>) : title}
+        </h4>
+        <p>
+            {`${startTime}-${endTime}`}
+        </p>
+        {speakers && (
+            <p>
+                {speakers.map((speaker, index) => (
+                    <span key={speaker.name}>
+                        {`${index > 0 ? ", " : ""} ${speaker.name}`}
+                    </span>
+                ))}
+            </p>
+        )}
+    </div>
+);
+
+Event.propTypes = {
+    title: PropTypes.string.isRequired,
+    startTime: PropTypes.string.isRequired,
+    endTime: PropTypes.string.isRequired,
+    speakers: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            occupations: PropTypes.arrayOf(
+                PropTypes.shape({
+                    what: PropTypes.string,
+                    where: PropTypes.string,
+                })
+            ).isRequired,
+        })
+    ),
+    slug: PropTypes.string,
+};
+
+export default Event;

--- a/src/components/schedule/Event.js
+++ b/src/components/schedule/Event.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
+import { SpeakerShape } from "../../utils/props";
 
 const Event = ({ title, startTime, endTime, speakers, slug }) => (
     <div>
@@ -15,11 +16,7 @@ const Event = ({ title, startTime, endTime, speakers, slug }) => (
         </p>
         {speakers && (
             <p>
-                {speakers.map((speaker, index) => (
-                    <span key={speaker.name}>
-                        {`${index > 0 ? ", " : ""} ${speaker.name}`}
-                    </span>
-                ))}
+                {speakers.map((speaker) => (speaker.name)).join(", ")}
             </p>
         )}
     </div>
@@ -31,13 +28,8 @@ Event.propTypes = {
     endTime: PropTypes.string.isRequired,
     speakers: PropTypes.arrayOf(
         PropTypes.shape({
-            name: PropTypes.string.isRequired,
-            occupations: PropTypes.arrayOf(
-                PropTypes.shape({
-                    what: PropTypes.string,
-                    where: PropTypes.string,
-                })
-            ).isRequired,
+            name: SpeakerShape.name,
+            occupations: SpeakerShape.occupations,
         })
     ),
     slug: PropTypes.string,

--- a/src/components/schedule/Schedule.js
+++ b/src/components/schedule/Schedule.js
@@ -1,0 +1,63 @@
+import { graphql, useStaticQuery } from "gatsby";
+import React from "react";
+import Event from "./Event";
+
+const Schedule = () => {
+    const data = useStaticQuery(graphql`
+    {
+      allMarkdownRemark(
+        filter: { fileAbsolutePath: { regex: "/data/events/" } }
+        sort: { fields: frontmatter___startTime }
+      ) {
+        group(field: frontmatter___date) {
+          fieldValue
+          edges {
+            node {
+              fields {
+                slug
+              }
+              frontmatter {
+                title
+                type
+                date(formatString: "D MMMM", locale: "en-US")
+                startTime
+                endTime
+                speakers {
+                  name
+                  occupations {
+                    what
+                    where
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+
+    return (
+        <div>
+            <h2>Schedule</h2>
+            {data.allMarkdownRemark.group.map((group) => (
+                <div key={group.fieldValue}>
+                    <h3>
+                        {group.edges[0].node.frontmatter.date}
+                    </h3>
+                    <div>
+                        {group.edges.map(({ node }) => (
+                            <Event
+                                key={node.frontmatter.title}
+                                {...node.frontmatter}
+                                {...node.fields}
+                            />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default Schedule;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,6 +5,7 @@ import Layout from "../components/layout";
 import Image from "../components/image";
 import Seo from "../components/seo";
 import Sponsors from "../components/sponsor/sponsors";
+import Schedule from "../components/schedule/Schedule";
 
 const IndexPage = () => {
     const message = useStaticQuery(graphql`
@@ -33,6 +34,7 @@ const IndexPage = () => {
             {" "}
             <br />
             <Sponsors />
+            <Schedule />
         </Layout>
     );
 };


### PR DESCRIPTION
# Description

Added Schedule component to the homepage that displays events from both days in chronological order. We can later tweak what information is displayed for each event depending on the mock-ups.

# Tasks

- [x] Display events in chronological order
- [x] Link events to standalone page